### PR TITLE
related talks without talks on the same playlist and channel

### DIFF
--- a/templates/details-talk.html
+++ b/templates/details-talk.html
@@ -51,8 +51,8 @@
             <!-- related talks -->
             <div class="related-talks col-md-4">
                 <h3>Related talks</h3>
-                {% if object.tags.similar_objects %}
-                    {% include "_partials/list_related_talks.html" with object_list=object.tags.similar_objects|slice:":15" %}
+                {% if related_talks %}
+                    {% include "_partials/list_related_talks.html" with object_list=related_talks %}
                 {% else %}
                     <p>No results.</p>
                 {% endif %}

--- a/web/talks/views.py
+++ b/web/talks/views.py
@@ -87,6 +87,9 @@ class DetailTalkView(DetailView):
         hot_talks = Talk.objects.all().order_by('-hacker_hot', '-youtube_view_count', '-youtube_like_count', 'youtube_dislike_count', '-created', '-updated')[:4]
         context['hot_talks'] = hot_talks
 
+        similar_objects_ids = [t.id for t in talk.tags.similar_objects()]
+        context['related_talks'] = Talk.objects.filter(id__in=similar_objects_ids).exclude(channel=talk.channel).exclude(playlist=talk.playlist)[:15]
+
         return context
 
 


### PR DESCRIPTION
## Description

related talks without talks on the same playlist and channel, there will be probably in the future sections about talks on the same channel (event?) and talks on the same edition (event edition?). 

## Approach

* similar_objects* returns a list not a queryset. So first we need to get a queryset from that list and then filter excluding all talks that belongs to the same channel and playlist.